### PR TITLE
fix adapter_name issue

### DIFF
--- a/GRETunnel.cpp
+++ b/GRETunnel.cpp
@@ -142,7 +142,7 @@ int main(int argc, char* argv[])
 		return 0;
 	}
 
-	Adapter = WintunCreateAdapter(L"GRE_Tunnel", adapter_name, NULL);
+	Adapter = WintunCreateAdapter(adapter_name, L"GRE_Tunnel", NULL);
 	if (!Adapter) {
 		LOG(FATAL) << "Failed to create Wintun adapter: " << GetLastError();
 		return 0;


### PR DESCRIPTION
Because line 179 `(set address name=\"%s\")` not same as line 145(adapter_name)
so error `The filename, directory name, or volume label syntax is incorrect.` appears